### PR TITLE
Set worker error when `parent_loop` raises an exception.

### DIFF
--- a/lib/servolux/prefork.rb
+++ b/lib/servolux/prefork.rb
@@ -365,6 +365,8 @@ class Servolux::Prefork
           Thread.current[:stop] = false
           response = parent_loop
         # TODO: put a logger here to catch and log all exceptions
+        rescue Exception => err
+          @error = err
         ensure
           @harvest << @piper.pid
           close_parent


### PR DESCRIPTION
Hullo =)

I've been playing with `Servolux::Prefork`, using a timeout.
If the timeout expires and the fork is killed, I'd like to restart it.

However, I can't see a way to check this?

The attached change, sets the error attr like other exceptions raised by the child would.

Thank you very much for servolux!! =)

Luke
