### PR TITLE
Pass original child exception backtrace up the exception chain.

### DIFF
--- a/lib/servolux/daemon.rb
+++ b/lib/servolux/daemon.rb
@@ -392,7 +392,7 @@ private
     started = wait_for {
       rv = started?
       err = @piper.gets
-      raise StartupError, "Child raised error: #{err.inspect}" unless err.nil?
+      raise StartupError, "Child raised error: #{err.inspect}", err.backtrace unless err.nil?
       rv
     }
 


### PR DESCRIPTION
Simple change, add the child exception backtrace when reraising as StartupError.

For me, in this instance, it was much easier to figure out my mistake when the extra backtrace information was available.

**Example backtrace before change:**

```
Child raised error: #<TypeError: no implicit conversion from nil to integer>
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/daemon.rb:395:in `block in wait_for_startup'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/daemon.rb:425:in `block in wait_for'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/daemon.rb:418:in `loop'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/daemon.rb:418:in `wait_for'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/daemon.rb:392:in `wait_for_startup'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/daemon.rb:254:in `block in startup'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/piper.rb:234:in `call'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/piper.rb:234:in `parent'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/daemon.rb:252:in `startup'
/Users/lantins/devel/iris/imss-end-point/lib/imss/end-point/command_line.rb:123:in `run_daemon!'
/Users/lantins/devel/iris/imss-end-point/lib/imss/end-point/command_line.rb:16:in `run!'
/Users/lantins/devel/iris/imss-end-point/lib/imss/end-point.rb:26:in `run!'
bin/imss-end-point:13:in `<main>'
```

**Example backtrace after change:**

```
Child raised error: #<TypeError: no implicit conversion from nil to integer>
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/syslogger-1.2.5/lib/syslogger.rb:78:in `LOG_UPTO'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/syslogger-1.2.5/lib/syslogger.rb:78:in `block in add'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/syslogger-1.2.5/lib/syslogger.rb:77:in `open'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/syslogger-1.2.5/lib/syslogger.rb:77:in `add'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/syslogger-1.2.5/lib/syslogger.rb:54:in `block (2 levels) in <class:Syslogger>'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/server.rb:253:in `create_pid_file'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/server.rb:193:in `startup'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/daemon.rb:347:in `run_startup_command'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/daemon.rb:258:in `block in startup'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/piper.rb:206:in `call'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/piper.rb:206:in `child'
/Users/lantins/.rvm/gems/ruby-1.9.2-p290/gems/servolux-0.9.7/lib/servolux/daemon.rb:258:in `startup'
/Users/lantins/devel/iris/imss-end-point/lib/imss/end-point/command_line.rb:123:in `run_daemon!'
/Users/lantins/devel/iris/imss-end-point/lib/imss/end-point/command_line.rb:16:in `run!'
/Users/lantins/devel/iris/imss-end-point/lib/imss/end-point.rb:26:in `run!'
bin/imss-end-point:13:in `<main>'
```
