### PR TITLE
Fix server shutdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ install:        "rake gem:install_dependencies"
 script: "rake"
 
 rvm:
-  - 1.8.7
-  - 1.9.2
-
+  - 1.9.3
+  - 2.1.5
+  - 2.2.2

--- a/examples/preforking_server.rb
+++ b/examples/preforking_server.rb
@@ -114,15 +114,17 @@ class PreforkingServerExample < ::Servolux::Server
 
   # Add a worker to the pool when USR1 is received
   def usr1
-    log "Adding a worker"
-    @pool.add_workers
+    Thread.new {
+      log "Adding a worker"
+      @pool.add_workers
+    }
   end
 
   # kill all the current workers with a usr2, the run loop will respawn up to
   # the min_worker count
   #
   def usr2
-    shutdown_workers
+    Thread.new { shutdown_workers }
   end
 
   # By default, Servolux::Server will capture the TERM signal and call its

--- a/examples/preforking_server.rb
+++ b/examples/preforking_server.rb
@@ -114,17 +114,15 @@ class PreforkingServerExample < ::Servolux::Server
 
   # Add a worker to the pool when USR1 is received
   def usr1
-    Thread.new {
-      log "Adding a worker"
-      @pool.add_workers
-    }
+    log "Adding a worker"
+    @pool.add_workers
   end
 
   # kill all the current workers with a usr2, the run loop will respawn up to
   # the min_worker count
   #
   def usr2
-    Thread.new { shutdown_workers }
+    shutdown_workers
   end
 
   # By default, Servolux::Server will capture the TERM signal and call its

--- a/lib/servolux.rb
+++ b/lib/servolux.rb
@@ -1,4 +1,3 @@
-
 module Servolux
 
   # :stopdoc:

--- a/lib/servolux/server.rb
+++ b/lib/servolux/server.rb
@@ -266,10 +266,17 @@ class Servolux::Server
 
   def trap_signals
     SIGNALS.each do |sig|
-      m = sig.downcase.to_sym
-      if self.respond_to? m
+      method = sig.downcase.to_sym
+      if self.respond_to? method
         Signal.trap(sig) do
-          Thread.new { self.send(m) rescue nil }
+          Thread.new do
+            begin
+              self.send(method)
+            rescue StandardError => err
+              logger.error "Exception in signal handler: #{method}"
+              logger.error err
+            end
+          end
         end
       end
     end

--- a/lib/servolux/server.rb
+++ b/lib/servolux/server.rb
@@ -236,8 +236,12 @@ class Servolux::Server
     self
   end
 
-  alias :int :shutdown     # handles the INT signal
-  alias :term :shutdown    # handles the TERM signal
+  # Handle the TERM signal and call `shutdown` on the server.
+  def term
+    Thread.new { shutdown }
+  end
+
+  alias :int :term      # handles the INT signal
   private :start, :stop
 
   # Returns the PID file name used by the server. If none was given, then

--- a/lib/servolux/server.rb
+++ b/lib/servolux/server.rb
@@ -190,9 +190,9 @@ class Servolux::Server
     }
 
     begin
+      trap_signals
       create_pid_file
       start
-      trap_signals
       join
       wait_for_shutdown if wait
     ensure


### PR DESCRIPTION
Wrap signal handlers in `Thread.new` so that mutexes can be used safely. This is a restriction of the Ruby interpreter - it prevents deadlocks from occurring.

fixes #14