### PR TITLE
Improving some error handling

### DIFF
--- a/lib/servolux/child.rb
+++ b/lib/servolux/child.rb
@@ -121,7 +121,7 @@ class Servolux::Child
     end
 
     kill if alive?
-    @io.close rescue nil
+    @io.close unless @io.nil? || @io.closed?
     @io = nil
     self
   end

--- a/lib/servolux/daemon.rb
+++ b/lib/servolux/daemon.rb
@@ -363,9 +363,9 @@ private
 
     skip = [STDIN, STDOUT, STDERR]
     skip << @piper.socket if @piper
-    ObjectSpace.each_object(IO) { |obj|
-      next if skip.include? obj
-      obj.close rescue nil
+    ObjectSpace.each_object(IO) { |io|
+      next if skip.include? io
+      io.close unless io.closed?
     }
 
     before_exec.call if before_exec.respond_to? :call

--- a/lib/servolux/piper.rb
+++ b/lib/servolux/piper.rb
@@ -153,7 +153,7 @@ class Servolux::Piper
   # @return [Piper] self
   #
   def close
-    @socket.close rescue nil
+    @socket.close unless @socket.closed?
     self
   end
 


### PR DESCRIPTION
There is a proliferation of `rescue nil` in the servolux codebase. Although convenient, this style of rescue statement only serves to obscure legitimate errors in the application. Where possible I've gone through and replaced those calls with better error handling.