### PR TITLE
Worker options

### DIFF
--- a/examples/server_beanstalk.rb
+++ b/examples/server_beanstalk.rb
@@ -32,7 +32,9 @@ module BeanstalkWorkerPool
   # Before we start the server run loop, allocate our pool of child workers
   # and prefork seven JobProcessors to pull work from the beanstalk queue.
   def before_starting
-    @pool = Servolux::Prefork.new(:module => JobProcessor)
+    @pool = Servolux::Prefork.new \
+      :module => JobProcessor,
+      :config => {:host => '127.0.0.1', :port => 11300}
     @pool.start 7
   end
 
@@ -57,7 +59,9 @@ end
 # See the beanstalk.rb example for an explanation of the JobProcessor
 module JobProcessor
   def before_executing
-    @beanstalk = Beanstalk::Pool.new(['localhost:11300'])
+    host = config[:host]
+    port = config[:port]
+    @beanstalk = Beanstalk::Pool.new(["#{host}:#{port}"])
   end
 
   def after_executing

--- a/lib/servolux/prefork.rb
+++ b/lib/servolux/prefork.rb
@@ -173,6 +173,7 @@ class Servolux::Prefork
     @min_workers = opts.fetch(:min_workers, nil)
     @module = Module.new { define_method :execute, &block } if block
     @workers = []
+    @worker_opts = opts.fetch(:worker_opts, {})
 
     raise ArgumentError, 'No code was given to execute by the workers.' unless @module
   end
@@ -245,7 +246,7 @@ class Servolux::Prefork
   def add_workers( number = 1 )
     number.times do
       break if at_max_workers?
-      worker = Worker.new( self )
+      worker = Worker.new( self, @worker_opts )
       worker.extend @module
       worker.start
       @workers << worker
@@ -364,8 +365,9 @@ private
     #
     # @param [Prefork] prefork The prefork pool that created this worker.
     #
-    def initialize( prefork )
+    def initialize( prefork, opts )
       @timeout = prefork.timeout
+      @opts = opts
       @thread = nil
       @piper = nil
       @error = nil

--- a/lib/servolux/prefork.rb
+++ b/lib/servolux/prefork.rb
@@ -141,6 +141,7 @@ class Servolux::Prefork
   attr_accessor :timeout     # Communication timeout in seconds.
   attr_accessor :min_workers # Minimum number of workers
   attr_accessor :max_workers # Maximum number of workers
+  attr_accessor :config      # Worker configuration options (a Hash)
 
   # call-seq:
   #    Prefork.new { block }
@@ -171,9 +172,9 @@ class Servolux::Prefork
     @module = opts.fetch(:module, nil)
     @max_workers = opts.fetch(:max_workers, nil)
     @min_workers = opts.fetch(:min_workers, nil)
+    @config = opts.fetch(:config, {})
     @module = Module.new { define_method :execute, &block } if block
     @workers = []
-    @worker_opts = opts.fetch(:worker_opts, {})
 
     raise ArgumentError, 'No code was given to execute by the workers.' unless @module
   end
@@ -246,7 +247,7 @@ class Servolux::Prefork
   def add_workers( number = 1 )
     number.times do
       break if at_max_workers?
-      worker = Worker.new( self, @worker_opts )
+      worker = Worker.new(self, @config)
       worker.extend @module
       worker.start
       @workers << worker
@@ -361,13 +362,16 @@ private
 
     attr_reader :error
 
+    attr_reader :config
+
     # Create a new worker that belongs to the _prefork_ pool.
     #
     # @param [Prefork] prefork The prefork pool that created this worker.
+    # @param [Hash] config The worker configuration options.
     #
-    def initialize( prefork, opts )
+    def initialize( prefork, config )
       @timeout = prefork.timeout
-      @opts = opts
+      @config = config
       @thread = nil
       @piper = nil
       @error = nil


### PR DESCRIPTION
This PR adds a `:config` option to the pre-fork worker pool. These configuration options will be passed to each worker and made available via the `config` method on the worker. You can use this options hash to pass connection information to the worker, for example.

closes #10

/cc @hollow @tigerw