### PR TITLE
Use a self-pipe for signal handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ announcement.txt
 coverage
 doc
 pkg
+tags
 .yardoc
 .rvmrc
 vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 
+notifications:
+  email: false
+
 before_install: "gem install bones"
 install:        "rake gem:install_dependencies"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:        "rake gem:install_dependencies"
 script: "rake"
 
 rvm:
-  - 1.9.3-p551
   - 2.1.10
   - 2.2.6
   - 2.3.3
+  - 2.4.0

--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,19 @@
+== 0.12.0 / 2015-06-07
+
+* Minor Enhancements
+  * Adding support for a `PidFile` class [pr #19]
+* Bug Fixes
+
+== 0.11.0 / 2015-05-29
+
+* Minor Enhancements
+  * Fixing server shutdown and signal handling in Ruby 2.0 and up [pr #16]
+  * Improving error handling [pr #17]
+  * Added worker options [pr #18]
+  * Added a `boostrap` script for easier development
+* Bug Fixes
+  * Typo and documentation fixes
+
 == 0.10.0 / 2012-02-18
 
 * Minor Enhancements

--- a/lib/servolux.rb
+++ b/lib/servolux.rb
@@ -37,6 +37,6 @@ module Servolux
   end
 end
 
-%w[version null_logger threaded pid_file server piper daemon child prefork].each do |lib|
+%w[version threaded child daemon null_logger pid_file piper prefork server].each do |lib|
   require Servolux.libpath('servolux', lib)
 end

--- a/lib/servolux/child.rb
+++ b/lib/servolux/child.rb
@@ -149,7 +149,7 @@ class Servolux::Child
   #   the child process is not running.
   #
   def wait( flags = 0 )
-    return if @io.nil?
+    return if @pid.nil?
     _, @status = Process.wait2(@pid, flags) unless @status
     exitstatus
   end
@@ -160,7 +160,7 @@ class Servolux::Child
   # @return [Boolean]
   #
   def alive?
-    return if @io.nil?
+    return if @pid.nil?
     wait(Process::WNOHANG|Process::WUNTRACED)
     Process.kill(0, @pid)
     true

--- a/lib/servolux/piper.rb
+++ b/lib/servolux/piper.rb
@@ -69,7 +69,9 @@ class Servolux::Piper
     piper.parent {
       pid = piper.gets
       raise ::Servolux::Error, 'Could not get the child PID.' if pid.nil?
-      piper.instance_variable_set(:@child_pid, pid)
+
+      piper.wait                                     # reap the child process
+      piper.instance_variable_set(:@child_pid, pid)  # adopt the grandchild
     }
     piper.child {
       Process.setsid                     # Become session leader.

--- a/lib/servolux/piper.rb
+++ b/lib/servolux/piper.rb
@@ -358,7 +358,7 @@ class Servolux::Piper
     wait(Process::WNOHANG|Process::WUNTRACED)
     Process.kill(0, @child_pid)
     true
-  rescue Errno::ESRCH, Errno::ENOENT
+  rescue Errno::ESRCH, Errno::ENOENT, Errno::ECHILD
     false
   end
 

--- a/lib/servolux/prefork.rb
+++ b/lib/servolux/prefork.rb
@@ -261,7 +261,7 @@ class Servolux::Prefork
   # Remove workers that are no longer alive from the worker pool
   #
   def prune_workers
-    new_workers = @workers.find_all { |w| w.alive? }
+    new_workers = @workers.find_all { |w| w.reap.alive? }
     @workers = new_workers
   end
 

--- a/lib/servolux/prefork.rb
+++ b/lib/servolux/prefork.rb
@@ -209,7 +209,7 @@ class Servolux::Prefork
   # @return [Prefork] self
   #
   def reap
-    @workers.each { |worker| worker.alive? }
+    @workers.each { |worker| worker.reap }
     self
   end
 
@@ -375,6 +375,7 @@ private
       @thread = nil
       @piper = nil
       @error = nil
+      @pid_list = []
     end
 
     # Start this worker. A new process will be forked, and the code supplied
@@ -383,6 +384,7 @@ private
     # @return [Worker] self
     #
     def start
+      @pid_list << @piper.pid if @piper
       @error = nil
       @piper = ::Servolux::Piper.new('rw', :timeout => @timeout)
       @piper.parent? ? parent : child
@@ -414,7 +416,7 @@ private
     #
     def wait
       return if @piper.nil? or @piper.child?
-      @piper.wait(Process::WNOHANG|Process::WUNTRACED)
+      @piper.wait(Process::WUNTRACED)
     end
 
     # Send this given _signal_ to the child process. The default signal is
@@ -441,9 +443,32 @@ private
     #
     def alive?
       return if @piper.nil?
-      return true if @piper.alive?
-      @piper = nil
+      @piper.alive?
+    end
+
+    # Internal: Attempt to reap any child processes spawned by this worker. If a
+    # child has exited, then we remove it from our PID list.
+    #
+    # @return [Worker] this worker instance.
+    def reap
+      @piper.alive? unless @piper.nil?
+      @pid_list.dup.each do |pid|
+        @pid_list.delete(pid) if reap?(pid)
+      end
+      self
+    end
+
+    # Internal: Check the return status of the given child PID. This will reap
+    # the process from the kernel process table if the child has exited.
+    #
+    # @return [Boolean] true if the PID has exited; false otherwise.
+    def reap?(pid)
+      _, cstatus = Process.wait2(pid, Process::WNOHANG|Process::WUNTRACED)
+      return true if cstatus
+      Process.kill(0, pid)
       false
+    rescue Errno::ESRCH, Errno::ENOENT, Errno::ECHILD
+      true
     end
 
     # Returns +true+ if communication with the child process timed out.

--- a/lib/servolux/prefork.rb
+++ b/lib/servolux/prefork.rb
@@ -441,7 +441,9 @@ private
     #
     def alive?
       return if @piper.nil?
-      @piper.alive?
+      return true if @piper.alive?
+      @piper = nil
+      false
     end
 
     # Returns +true+ if communication with the child process timed out.

--- a/lib/servolux/server.rb
+++ b/lib/servolux/server.rb
@@ -261,8 +261,11 @@ class Servolux::Server
   private
 
   def close_signal_pipe
+    if defined?(@wr) && !@wr.nil? && !@wr.closed?
+      @wr.write_nonblock("!")
+      @wr.close
+    end
     @rd.close if defined?(@rd) && !@rd.nil? && !@rd.closed?
-    @wr.close if defined?(@wr) && !@wr.nil? && !@wr.closed?
   end
 
   def trap_signals
@@ -295,7 +298,7 @@ class Servolux::Server
         self.send(method)
       rescue IO::WaitReadable
         retry
-      rescue EOFError, Errno::EBADF
+      rescue IOError, EOFError, Errno::EBADF
         logger.info "Signal processing thread has stopped"
         break
       rescue StandardError => err

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,7 +2,7 @@
 
 gem list -i bones >/dev/null 2>&1
 rc=$?
-if [[ $rc != 0 ]]; then
+if [ "$rc" != "0" ]; then
   gem install bones
 fi
 

--- a/spec/prefork_spec.rb
+++ b/spec/prefork_spec.rb
@@ -31,7 +31,7 @@ describe Servolux::Prefork do
 
   def wait_until( seconds = 5 )
     start = Time.now
-    sleep 0.250 until (Time.now - start) > seconds or yield
+    sleep 0.250 until ((Time.now - start) > seconds) || yield
   end
 
   before :all do

--- a/spec/prefork_spec.rb
+++ b/spec/prefork_spec.rb
@@ -21,7 +21,7 @@ describe Servolux::Prefork do
   end
 
   def alive?( pid )
-    _, cstatus = Process.wait2( pid, Process::WNOHANG )
+    _, cstatus = Process.wait2(pid, Process::WNOHANG|Process::WUNTRACED)
     return false if cstatus
     Process.kill(0, pid)
     true

--- a/spec/prefork_spec.rb
+++ b/spec/prefork_spec.rb
@@ -125,36 +125,23 @@ describe Servolux::Prefork do
   end
 
   it "starts up a stopped worker" do
-STDOUT.puts "#"*5
     @prefork = Servolux::Prefork.new :module => @worker, :config => {:path => @path}
-STDOUT.puts "#{__FILE__}: #{__LINE__}"
     @prefork.start 2
-STDOUT.puts "#{__FILE__}: #{__LINE__}"
     ary = workers
-STDOUT.puts "#{__FILE__}: #{__LINE__}"
     wait_until { ary.all? { |w| w.alive? } }
-STDOUT.puts "#{__FILE__}: #{__LINE__}"
     wait_until { worker_count >= 2 }
-STDOUT.puts "#{__FILE__}: #{__LINE__}"
 
     pid = pids.last
-STDOUT.puts "#{__FILE__}: #{__LINE__}"
     ary.last.signal 'TERM'
-STDOUT.puts "#{__FILE__}: #{__LINE__}"
 
     wait_until { !alive? pid }
-STDOUT.puts "#{__FILE__}: #{__LINE__}"
     @prefork.reap
-STDOUT.puts "#{__FILE__}: #{__LINE__}"
+
     @prefork.each_worker do |worker|
       worker.start unless worker.alive?
     end
-STDOUT.puts "#{__FILE__}: #{__LINE__}"
     wait_until { ary.all? { |w| w.alive? } }
-STDOUT.puts "#{__FILE__}: #{__LINE__}"
     expect(pid).not_to eq(pids.last)
-STDOUT.puts "#{__FILE__}: #{__LINE__}"
-STDOUT.puts "#"*5
   end
 
   it "adds a new worker to the worker pool" do

--- a/spec/prefork_spec.rb
+++ b/spec/prefork_spec.rb
@@ -126,21 +126,34 @@ describe Servolux::Prefork do
   end
 
   it "starts up a stopped worker" do
+STDOUT.puts "#"*5
     @prefork = Servolux::Prefork.new :module => @worker, :config => {:path => @path}
+STDOUT.puts "#{__FILE__}: #{__LINE__}"
     @prefork.start 2
+STDOUT.puts "#{__FILE__}: #{__LINE__}"
     ary = workers
+STDOUT.puts "#{__FILE__}: #{__LINE__}"
     wait_until { ary.all? { |w| w.alive? } }
+STDOUT.puts "#{__FILE__}: #{__LINE__}"
     wait_until { worker_count >= 2 }
+STDOUT.puts "#{__FILE__}: #{__LINE__}"
 
     pid = pids.last
+STDOUT.puts "#{__FILE__}: #{__LINE__}"
     ary.last.signal 'TERM'
+STDOUT.puts "#{__FILE__}: #{__LINE__}"
 
     @prefork.reap until !alive? pid
+STDOUT.puts "#{__FILE__}: #{__LINE__}"
     @prefork.each_worker do |worker|
       worker.start unless worker.alive?
     end
+STDOUT.puts "#{__FILE__}: #{__LINE__}"
     wait_until { ary.all? { |w| w.alive? } }
+STDOUT.puts "#{__FILE__}: #{__LINE__}"
     expect(pid).not_to eq(pids.last)
+STDOUT.puts "#{__FILE__}: #{__LINE__}"
+STDOUT.puts "#"*5
   end
 
   it "adds a new worker to the worker pool" do

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -5,7 +5,7 @@ describe Servolux::Server do
 
   def wait_until( seconds = 5 )
     start = Time.now
-    sleep 0.250 until (Time.now - start) > seconds or yield
+    sleep 0.250 until ((Time.now - start) > seconds) || yield
   end
 
   def readlog

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -8,6 +8,10 @@ describe Servolux::Server do
     sleep 0.250 until (Time.now - start) > seconds or yield
   end
 
+  def readlog
+    @log_output.readline
+  end
+
   base = Class.new(Servolux::Server) do
     def initialize
       super('Test Server', :logger => Logging.logger['Servolux'])
@@ -23,62 +27,63 @@ describe Servolux::Server do
   after :each do
     @server.shutdown
     @server.wait_for_shutdown
+    wait_until { @t.status == false } if @t && @t.alive?
   end
 
   it 'generates a PID file' do
     expect(@server.pid_file).to_not exist
 
-    t = Thread.new {@server.startup}
-    wait_until { @server.running? and t.status == 'sleep' }
+    @t = Thread.new {@server.startup}
+    wait_until { @server.running? and @t.status == 'sleep' }
     expect(@server.pid_file).to exist
 
     @server.shutdown
-    wait_until { t.status == false }
+    wait_until { @t.status == false }
     expect(@server.pid_file).to_not exist
   end
 
   it 'generates a PID file with mode rw-r----- by default' do
-    t = Thread.new {@server.startup}
-    wait_until { @server.running? and t.status == 'sleep' }
+    @t = Thread.new {@server.startup}
+    wait_until { @server.running? and @t.status == 'sleep' }
     expect(@server.pid_file).to exist
 
-    expect(@log_output.readline.chomp).to eq(%q(DEBUG  Servolux : Writing pid file "./test_server.pid"))
-    expect(@log_output.readline.chomp).to eq(%q(DEBUG  Servolux : Starting))
+    expect(readlog.chomp).to eq(%q(DEBUG  Servolux : Writing pid file "./test_server.pid"))
+    expect(readlog.chomp).to eq(%q(DEBUG  Servolux : Starting))
 
     filename = @server.pid_file.filename
     mode = File.stat(filename).mode & 0777
     expect(mode).to eq(0640)
 
     @server.shutdown
-    wait_until { t.status == false }
+    wait_until { @t.status == false }
     expect(@server.pid_file).to_not exist
   end
 
   it 'generates PID file with the specified permissions' do
     @server.pid_file.mode = 0400
-    t = Thread.new {@server.startup}
-    wait_until { @server.running? and t.status == 'sleep' }
+    @t = Thread.new {@server.startup}
+    wait_until { @server.running? and @t.status == 'sleep' }
     expect(@server.pid_file).to exist
 
-    expect(@log_output.readline.chomp).to eq(%q(DEBUG  Servolux : Writing pid file "./test_server.pid"))
-    expect(@log_output.readline.chomp).to eq(%q(DEBUG  Servolux : Starting))
+    expect(readlog.chomp).to eq(%q(DEBUG  Servolux : Writing pid file "./test_server.pid"))
+    expect(readlog.chomp).to eq(%q(DEBUG  Servolux : Starting))
 
     filename = @server.pid_file.filename
     mode = File.stat(filename).mode & 0777
     expect(mode).to eq(0400)
 
     @server.shutdown
-    wait_until { t.status == false }
+    wait_until { @t.status == false }
     expect(@server.pid_file).to_not exist
   end
 
   it 'shuts down gracefully when signaled' do
-    t = Thread.new {@server.startup}
-    wait_until { @server.running? and t.status == 'sleep' }
+    @t = Thread.new {@server.startup}
+    wait_until { @server.running? and @t.status == 'sleep' }
     expect(@server).to be_running
 
-    `kill -SIGINT #{$$}`
-    wait_until { t.status == false }
+    Process.kill 'SIGINT', $$
+    wait_until { @t.status == false }
     expect(@server).to_not be_running
   end
 
@@ -89,31 +94,31 @@ describe Servolux::Server do
       def usr2() logger.info 'usr2 was called'; end
     end
 
-    t = Thread.new {@server.startup}
-    wait_until { @server.running? and t.status == 'sleep' }
-    @log_output.readline
-    expect(@log_output.readline.strip).to eq('DEBUG  Servolux : Starting')
+    @t = Thread.new {@server.startup}
+    wait_until { @server.running? and @t.status == 'sleep' }
+    readlog
+    expect(readlog.strip).to eq('DEBUG  Servolux : Starting')
 
     line = nil
     Process.kill 'SIGUSR1', $$
-    wait_until { line = @log_output.readline }
+    wait_until { line = readlog }
     expect(line).to_not be_nil
     expect(line.strip).to eq('INFO  Servolux : usr1 was called')
 
     line = nil
     Process.kill 'SIGHUP', $$
-    wait_until { line = @log_output.readline }
+    wait_until { line = readlog }
     expect(line).to_not be_nil
     expect(line.strip).to eq('INFO  Servolux : hup was called')
 
     line = nil
     Process.kill 'SIGUSR2', $$
-    wait_until { line = @log_output.readline }
+    wait_until { line = readlog }
     expect(line).to_not be_nil
     expect(line.strip).to eq('INFO  Servolux : usr2 was called')
 
     Process.kill 'SIGTERM', $$
-    wait_until { t.status == false }
+    wait_until { @t.status == false }
     expect(@server).to_not be_running
   end
 
@@ -122,20 +127,44 @@ describe Servolux::Server do
       def usr2() raise 'Ooops!'; end
     end
 
-    t = Thread.new {@server.startup}
-    wait_until { @server.running? and t.status == 'sleep' }
-    @log_output.readline
-    expect(@log_output.readline.strip).to eq('DEBUG  Servolux : Starting')
+    @t = Thread.new {@server.startup}
+    wait_until { @server.running? and @t.status == 'sleep' }
+    readlog
+    expect(readlog.strip).to eq('DEBUG  Servolux : Starting')
 
     line = nil
     Process.kill 'SIGUSR2', $$
-    wait_until { line = @log_output.readline }
+    wait_until { line = readlog }
     expect(line).to_not be_nil
     expect(line.strip).to eq('ERROR  Servolux : Exception in signal handler: usr2')
 
     line = nil
-    wait_until { line = @log_output.readline }
+    wait_until { line = readlog }
     expect(line).to_not be_nil
     expect(line.strip).to eq('ERROR  Servolux : <RuntimeError> Ooops!')
+  end
+
+  it 'logs when the signal handler thread exits' do
+    class << @server
+      def hup() logger.info 'hup was called'; end
+    end
+
+    @t = Thread.new {@server.startup}
+    wait_until { @server.running? and @t.status == 'sleep' }
+    readlog
+    expect(readlog.strip).to eq('DEBUG  Servolux : Starting')
+
+    line = nil
+    @server.__send__(:close_signal_pipe)
+    wait_until { line = readlog }
+    expect(line).to_not be_nil
+    expect(line.strip).to eq('INFO  Servolux : Signal processing thread has stopped')
+
+    line = nil
+    Process.kill 'SIGHUP', $$
+    wait_until { line = readlog }
+    expect(line).to_not be_nil
+    expect(line.strip).to    eq('ERROR  Servolux : Exception in signal handler: hup')
+    expect(readlog.strip).to eq('ERROR  Servolux : <IOError> closed stream')
   end
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -155,7 +155,7 @@ describe Servolux::Server do
     expect(readlog.strip).to eq('DEBUG  Servolux : Starting')
 
     line = nil
-    @server.__send__(:close_signal_pipe)
+    @server.__send__(:halt_signal_processing)
     wait_until { line = readlog }
     expect(line).to_not be_nil
     expect(line.strip).to eq('INFO  Servolux : Signal processing thread has stopped')


### PR DESCRIPTION
This removes the nasty hack of spinning up a thread inside the signal handler. Now we are a using an `IO.pipe` to signal a separate thread to process the shutdown sequence (or whatever else needs to happen) of the Server.
